### PR TITLE
Add basic reports module using JFreeChart

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     // This dependency is used by the application.
     implementation libs.guava
+    implementation libs.jfreechart
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/app/src/main/java/financemanager/App.java
+++ b/app/src/main/java/financemanager/App.java
@@ -10,10 +10,8 @@ public class App {
          SwingUtilities.invokeLater(() -> {
             MainFrame frame = new MainFrame();
 
-            // // Register all modules
-            // frame.registerModule(new TransactionsPanel());
-            // frame.registerModule(new BudgetsPanel());
-            // frame.registerModule(new ReportsPanel());
+            // Register available modules
+            frame.registerModule(new financemanager.ui.modules.ReportsModule());
 
             frame.setVisible(true);
         });

--- a/app/src/main/java/financemanager/ui/modules/ReportsModule.java
+++ b/app/src/main/java/financemanager/ui/modules/ReportsModule.java
@@ -1,0 +1,59 @@
+package financemanager.ui.modules;
+
+import java.awt.BorderLayout;
+import javax.swing.Icon;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.category.DefaultCategoryDataset;
+
+import financemanager.core.Module;
+import financemanager.records.CSVFinanceRecordDAO;
+import financemanager.records.FinanceRecord;
+
+/**
+ * Module that displays a simple bar chart of all finance records using
+ * JFreeChart. Income and Expense records are plotted separately.
+ */
+public class ReportsModule implements Module {
+
+    private final JPanel panel;
+    private final Icon icon;
+
+    public ReportsModule() {
+        this.panel = new JPanel(new BorderLayout());
+        this.icon = UIManager.getIcon("FileView.directoryIcon");
+        initChart();
+    }
+
+    private void initChart() {
+        DefaultCategoryDataset dataset = new DefaultCategoryDataset();
+        CSVFinanceRecordDAO dao = new CSVFinanceRecordDAO();
+        for (FinanceRecord r : dao.getAllRecords()) {
+            dataset.addValue(r.getAmount(), r.getType(), r.getDate());
+        }
+
+        JFreeChart chart = ChartFactory.createBarChart(
+                "Finance Records", "Date", "Amount", dataset);
+        ChartPanel chartPanel = new ChartPanel(chart);
+        panel.add(chartPanel, BorderLayout.CENTER);
+    }
+
+    @Override
+    public String getModuleName() {
+        return "Reports";
+    }
+
+    @Override
+    public JPanel getPanel() {
+        return panel;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return icon;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,9 @@
 [versions]
 guava = "33.0.0-jre"
 junit-jupiter = "5.10.2"
+jfreechart = "1.5.4"
 
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+jfreechart = { module = "org.jfree:jfreechart", version.ref = "jfreechart" }


### PR DESCRIPTION
## Summary
- include JFreeChart dependency
- hook JFreeChart into the build
- implement `ReportsModule` that plots saved finance records
- register the new module in `App`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve org.jfree:jfreechart:1.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68487b1934388326bf600f436927c1c8